### PR TITLE
Configure wanted metrics with group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ api_key: "THE_API_KEY"
 skip_tls_verify: false
 group: ## a list of group names to monitor
   - name: "Dev"
+    servers:
+      - "Server"
   - name: "MyWonderfulMachines"
 ```
 The _skip_tls_verify_ option gives you the possibility to skip the certificate checking for self signed certs for example.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Startup Pause|8
 Training|12
 Unlicensed|9
  	
+
+The _status_mapping.yml_ file contains the values as float64 returned in the metrics for each string status returned by PowerAdmin. You can also specify a default value.
 	 
 
 
@@ -79,6 +81,7 @@ group: ## a list of group names to monitor
   - name: "Dev"
   - name: "MyWonderfulMachines"
 ```
+The _skip_tls_verify_ option gives you the possibility to skip the certificate checking for self signed certs for example.
 
 ## Docker image
 

--- a/collector_test.go
+++ b/collector_test.go
@@ -33,7 +33,7 @@ func (mock *MockPAExternalAPI) GetServerList(gid string) (*ServerList, error) {
 func TestCollector_Collect(t *testing.T) {
 	api := MockPAExternalAPI{}
 	collector := NewCollector(&api)
-	values := make([]MonitoredValue, 1)
+	values := make([]MonitoredValue, 2)
 	value := MonitoredValue{
 		MonitorTitle:   "Toto",
 		MonitorValue:   "OK",
@@ -42,7 +42,16 @@ func TestCollector_Collect(t *testing.T) {
 		ServerID:       "158",
 		GroupID:        "154",
 	}
+	value2 := MonitoredValue{
+		MonitorTitle:   "Albert",
+		MonitorValue:   "Not OK",
+		MonitorLastRun: time.Now(),
+		MonitorStatus:  "Not OK",
+		ServerID:       "158",
+		GroupID:        "154",
+	}
 	values[0] = value
+	values[1] = value2
 	m := MonitoredValues{
 		values,
 	}
@@ -65,7 +74,11 @@ func TestCollector_Collect(t *testing.T) {
 	for m := range ch {
 		got := readMetric(m)
 		assert.Equal(t, dto.MetricType_UNTYPED, got.metricType)
-		assert.Equal(t, float64(1), got.value)
+		if readOne {
+			assert.Equal(t, float64(0), got.value)
+		} else {
+			assert.Equal(t, float64(1), got.value)
+		}
 		readOne = true
 	}
 	assert.True(t, readOne)

--- a/config_example.yml
+++ b/config_example.yml
@@ -3,4 +3,7 @@ api_key: "THE_API_KEY"
 skip_tls_verify: true
 group:
   - name: "Dev"
+    servers:
+    - "Server1"
+    - "Server2"
   - name: "MyWonderfulMachines"

--- a/main.go
+++ b/main.go
@@ -31,7 +31,8 @@ type Config struct {
 
 // GroupFilter group selection
 type GroupFilter struct {
-	GroupName string `yaml:"name"`
+	GroupName string   `yaml:"name"`
+	Servers   []string `yaml:"servers"`
 }
 
 func init() {

--- a/paapi.go
+++ b/paapi.go
@@ -232,7 +232,7 @@ func (client *PAExternalAPIClient) GetResources(groupFilters []GroupFilter) (*Mo
 			if err != nil {
 				return nil, err
 			}
-			filteredServers := filterWantedServers(servers.Servers, filter.Servers)
+			filteredServers := filterServers(servers.Servers, filter.Servers)
 			for _, server := range filteredServers {
 				values, err := client.GetMonitorInfos(server.ID)
 				if err != nil {
@@ -257,7 +257,7 @@ func (client *PAExternalAPIClient) GetResources(groupFilters []GroupFilter) (*Mo
 	return &metrics, nil
 }
 
-func filterWantedServers(servers []Server, names []string) []Server {
+func filterServers(servers []Server, names []string) []Server {
 	if len(names) == 0 { // if no server names in filter, then it's like no filter
 		return servers
 	}

--- a/paapi.go
+++ b/paapi.go
@@ -232,8 +232,8 @@ func (client *PAExternalAPIClient) GetResources(groupFilters []GroupFilter) (*Mo
 			if err != nil {
 				return nil, err
 			}
-
-			for _, server := range servers.Servers {
+			filteredServers := filterWantedServers(servers.Servers, filter.Servers)
+			for _, server := range filteredServers {
 				values, err := client.GetMonitorInfos(server.ID)
 				if err != nil {
 					return nil, err
@@ -255,4 +255,22 @@ func (client *PAExternalAPIClient) GetResources(groupFilters []GroupFilter) (*Mo
 		}
 	}
 	return &metrics, nil
+}
+
+func filterWantedServers(servers []Server, names []string) []Server {
+	if len(names) == 0 { // if no server names in filter, then it's like no filter
+		return servers
+	}
+	namesSet := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		namesSet[name] = struct{}{}
+	}
+	newServers := make([]Server, 0)
+	for _, server := range servers {
+		if _, exists := namesSet[server.Name]; exists {
+			newServers = append(newServers, server)
+		}
+	}
+	return newServers
+
 }


### PR DESCRIPTION
Using this PR as a question ... I already implemented the config file. So question is ... 
- do we need to have a filter by server in addition to the group filter ? 
- do we have to take care of updates in the file like hot reload of the configuration ? there seem to be this possibility in azure_metric_exporter
